### PR TITLE
previewFile on button click instead of onchange

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,14 @@
         <input
           class="bg-white focus:outline-0 focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal mb-3"
           type="file"
-          onchange="previewFile()"
         />
+        <button
+          class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
+          id="preview"
+          onclick="previewFile()"
+        >
+          Preview
+        </button>
       </div>
       <div class="flex flex-wrap -mx-1 lg:-mx-4">
         <div class="mx-auto text-sm" style="width:99%;" id="output"></div>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 var list;
+var fetchedData;
 const search = () => {
   const term = document.getElementById("term").value;
   const url =
@@ -8,6 +9,7 @@ const search = () => {
       return response.json();
     })
     .then(function(data) {
+      fetchedData = data;
       displayResults(data);
     });
 };
@@ -26,6 +28,8 @@ search();
 // upload your own cover art:
 
 function previewFile() {
+  displayResults(fetchedData);  // recreate the original grid
+  
   var file = document.querySelector("input[type=file]").files[0];
   var title = document.querySelector("input#title").value;
   var reader = new FileReader();


### PR DESCRIPTION
Add a new "Preview" button.
call previewFile function onclick of the Preview Button,
instead of onchange of the file input box.

This allows users to reupload new images or change show name
without reloading the page (and doing a new search again).

We also need to keep a copy of the original JSON search result
so that we can repaint the original grid before randomly
inserting the new coverart.